### PR TITLE
RIS Year update

### DIFF
--- a/lib/anystyle/format/ris.rb
+++ b/lib/anystyle/format/ris.rb
@@ -11,8 +11,12 @@ module AnyStyle
         type = ris_type(entry[:type])
         lines << "TY  - #{type}"
 
+        if (date = ris_py_value(entry))
+          lines << date
+        end
+
         add_authors(lines, entry[:author])
-        lines << "PY  - #{unwrap(entry[:issued] || entry[:date])}" if entry[:issued] || entry[:date]
+        # lines << "PY  - #{unwrap(entry[:issued] || entry[:date])}" if entry[:issued] || entry[:date]
         lines << "TI  - #{unwrap(entry[:title])}" if entry[:title]
         lines << "T2  - #{unwrap(entry[:'container-title'])}" if entry[:'container-title']
         lines << "PB  - #{unwrap(entry[:publisher])}" if entry[:publisher]
@@ -72,6 +76,68 @@ module AnyStyle
 
           lines << "AU  - #{name}" if name
         end
+      end
+
+      # Build the PY value from :issued (CiteProc) or raw :date/:issued string
+      # def py_from_entry(entry)
+        # 1) Prefer structured CiteProc (:issued) if present
+        # issued = entry[:issued]
+        # if issued.is_a?(Hash)
+
+        #   raw = issued[:raw]
+        #   return ris_py_value(raw) if raw
+        # end
+
+        # 2) Otherwise, fall back to raw date strings
+      #   raw = unwrap(entry[:date])# || unwrap(entry[:issued])
+
+      #   ris_py_value(raw)
+      # end
+
+      # Emit "YYYY/MM/DD/", leaving missing parts empty. Year is mandatory.
+      def format_py(year, month = nil, day = nil)
+        return nil unless year
+        year_i = year.to_i
+        month_s = month.nil? || month.to_s.strip.empty? ? "" : month.to_i.to_s
+        day_s = day.nil? || day.to_s.strip.empty? ? "" : day.to_i.to_s
+        "%04d/%s/%s/" % [year_i, month_s, day_s]
+      end
+
+      # Parse loose date strings into "YYYY/MM/DD/". Handles:
+      # - "2024"
+      # - "4/8/1999" or "04-08-1999" (D/M/YYYY as per your requirement)
+      # - "1999-08-04" or "1999/08"
+      # - fuzzy strings with a detectable year ("ca. 2012")
+      def ris_py_value(entry)
+        date_raw = unwrap(entry[:date])
+      
+        return nil if date_raw.nil?
+        date_string = date_raw.to_s.strip
+        return nil if date_string.empty?
+
+        # Year only
+        if date_string =~ /\A\d{4}\z/
+          return "PY  - " + format_py(date_string.to_i)
+        end
+
+        # D/M/YYYY or DD-MM-YYYY (treat as day/month/year per your example)
+        if (matched = date_string.match(/\A(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{4})\z/))
+          day, month, year = matched[1].to_i, matched[2].to_i, matched[3].to_i
+          return "DA  - " + format_py(year, month, day)
+        end
+
+        # YYYY-M-D or YYYY/M or YYYY/M/D
+        if (matched = date_string.match(/\A(\d{4})[\/.-](\d{1,2})(?:[\/.-](\d{1,2}))?\z/))
+          year, month, day = matched[1].to_i, matched[2].to_i, (matched[3] && matched[3].to_i)
+          return "DA  - " + format_py(year, month, day)
+        end
+
+        # Fallback: extract a plausible year
+        if (matched = date_string.match(/\b(1[5-9]\d{2}|20\d{2}|2100)\b/))
+          return "PY  - " + format_py(matched[1].to_i)
+        end
+
+        nil
       end
     end
   end

--- a/lib/anystyle/format/ris.rb
+++ b/lib/anystyle/format/ris.rb
@@ -12,7 +12,7 @@ module AnyStyle
         lines << "TY  - #{type}"
 
         add_authors(lines, entry[:author])
-        lines << "PY  - #{unwrap(entry[:issued])}" if entry[:issued]
+        lines << "PY  - #{unwrap(entry[:issued] || entry[:date])}" if entry[:issued] || entry[:date]
         lines << "TI  - #{unwrap(entry[:title])}" if entry[:title]
         lines << "T2  - #{unwrap(entry[:'container-title'])}" if entry[:'container-title']
         lines << "PB  - #{unwrap(entry[:publisher])}" if entry[:publisher]

--- a/lib/anystyle/format/ris.rb
+++ b/lib/anystyle/format/ris.rb
@@ -78,22 +78,6 @@ module AnyStyle
         end
       end
 
-      # Build the PY value from :issued (CiteProc) or raw :date/:issued string
-      # def py_from_entry(entry)
-        # 1) Prefer structured CiteProc (:issued) if present
-        # issued = entry[:issued]
-        # if issued.is_a?(Hash)
-
-        #   raw = issued[:raw]
-        #   return ris_py_value(raw) if raw
-        # end
-
-        # 2) Otherwise, fall back to raw date strings
-      #   raw = unwrap(entry[:date])# || unwrap(entry[:issued])
-
-      #   ris_py_value(raw)
-      # end
-
       # Emit "YYYY/MM/DD/", leaving missing parts empty. Year is mandatory.
       def format_py(year, month = nil, day = nil)
         return nil unless year
@@ -104,10 +88,6 @@ module AnyStyle
       end
 
       # Parse loose date strings into "YYYY/MM/DD/". Handles:
-      # - "2024"
-      # - "4/8/1999" or "04-08-1999" (D/M/YYYY as per your requirement)
-      # - "1999-08-04" or "1999/08"
-      # - fuzzy strings with a detectable year ("ca. 2012")
       def ris_py_value(entry)
         date_raw = unwrap(entry[:date])
       
@@ -120,7 +100,7 @@ module AnyStyle
           return "PY  - " + format_py(date_string.to_i)
         end
 
-        # D/M/YYYY or DD-MM-YYYY (treat as day/month/year per your example)
+        # D/M/YYYY or DD-MM-YYYY
         if (matched = date_string.match(/\A(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{4})\z/))
           day, month, year = matched[1].to_i, matched[2].to_i, matched[3].to_i
           return "DA  - " + format_py(year, month, day)
@@ -133,7 +113,7 @@ module AnyStyle
         end
 
         # Fallback: extract a plausible year
-        if (matched = date_string.match(/\b(1[5-9]\d{2}|20\d{2}|2100)\b/))
+        if (matched = date_string.match(/\b(1?[0-9]\d{2}|20\d{2})\b/))
           return "PY  - " + format_py(matched[1].to_i)
         end
 

--- a/lib/anystyle/format/ris.rb
+++ b/lib/anystyle/format/ris.rb
@@ -16,7 +16,6 @@ module AnyStyle
         end
 
         add_authors(lines, entry[:author])
-        # lines << "PY  - #{unwrap(entry[:issued] || entry[:date])}" if entry[:issued] || entry[:date]
         lines << "TI  - #{unwrap(entry[:title])}" if entry[:title]
         lines << "T2  - #{unwrap(entry[:'container-title'])}" if entry[:'container-title']
         lines << "PB  - #{unwrap(entry[:publisher])}" if entry[:publisher]
@@ -94,7 +93,7 @@ module AnyStyle
         return nil if date_raw.nil?
         date_string = date_raw.to_s.strip
         return nil if date_string.empty?
-        
+
         #Extract year
         if (matched = date_string.match(/\b(1?[0-9]\d{2}|20\d{2})\b/))
           return "PY  - " + format_py(matched[1].to_i)

--- a/lib/anystyle/format/ris.rb
+++ b/lib/anystyle/format/ris.rb
@@ -78,7 +78,7 @@ module AnyStyle
         end
       end
 
-      # Emit "YYYY/MM/DD/", leaving missing parts empty. Year is mandatory.
+      # Emit "YYYY/MM/DD/", leaving missing parts empty
       def format_py(year, month = nil, day = nil)
         return nil unless year
         year_i = year.to_i
@@ -87,32 +87,15 @@ module AnyStyle
         "%04d/%s/%s/" % [year_i, month_s, day_s]
       end
 
-      # Parse loose date strings into "YYYY/MM/DD/". Handles:
+      # Parse loose date strings into "YYYY/MM/DD/"
       def ris_py_value(entry)
         date_raw = unwrap(entry[:date])
       
         return nil if date_raw.nil?
         date_string = date_raw.to_s.strip
         return nil if date_string.empty?
-
-        # Year only
-        if date_string =~ /\A\d{4}\z/
-          return "PY  - " + format_py(date_string.to_i)
-        end
-
-        # D/M/YYYY or DD-MM-YYYY
-        if (matched = date_string.match(/\A(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{4})\z/))
-          day, month, year = matched[1].to_i, matched[2].to_i, matched[3].to_i
-          return "DA  - " + format_py(year, month, day)
-        end
-
-        # YYYY-M-D or YYYY/M or YYYY/M/D
-        if (matched = date_string.match(/\A(\d{4})[\/.-](\d{1,2})(?:[\/.-](\d{1,2}))?\z/))
-          year, month, day = matched[1].to_i, matched[2].to_i, (matched[3] && matched[3].to_i)
-          return "DA  - " + format_py(year, month, day)
-        end
-
-        # Fallback: extract a plausible year
+        
+        #Extract year
         if (matched = date_string.match(/\b(1?[0-9]\d{2}|20\d{2})\b/))
           return "PY  - " + format_py(matched[1].to_i)
         end

--- a/spec/anystyle/format/ris_spec.rb
+++ b/spec/anystyle/format/ris_spec.rb
@@ -1,64 +1,79 @@
 require 'spec_helper'
 require_relative '../../../lib/anystyle/format/ris'
+module AnyStyle
+  describe AnyStyle::Format::RIS do
+    include AnyStyle::Format::RIS
 
-describe AnyStyle::Format::RIS do
-  include AnyStyle::Format::RIS
+    let(:ap) { Parser.new }
 
-  # Mock of the format_hash method
-  def format_hash(dataset)
-    dataset
-  end
+    # Mock of the format_hash method
+    def format_hash(dataset)
+      dataset
+    end
 
-  it 'formats a book reference in RIS format' do
-    data = [{
-      type: 'book',
-      author: [{ family: 'Doe', given: 'John' }],
-      date: '2023',
-      title: 'The Great Emu War',
-      publisher: 'Wiley',
-      ISBN: '9780245839459',
-      URL: 'https://example.com',
-      edition: '1',
-      'publisher-place': 'New York'
-    }]
+    it 'formats a book reference in RIS format' do
+      data = [{
+        type: 'book',
+        author: [{ family: 'Doe', given: 'John' }],
+        date: '2023',
+        title: 'The Great Emu War',
+        publisher: 'Wiley',
+        ISBN: '9780245839459',
+        URL: 'https://example.com',
+        edition: '1',
+        'publisher-place': 'New York'
+      }]
 
-    output = format_ris(data)
-    expect(output).to include("TY  - BOOK")
-    expect(output).to include("AU  - Doe, John")
-    expect(output).to include("TI  - The Great Emu War")
-    expect(output).to include("PY  - 2023")
-    expect(output).to include("SN  - 9780245839459")
-    expect(output).to include("ER  -")
-  end
+      output = format_ris(data)
+      expect(output).to include("TY  - BOOK")
+      expect(output).to include("AU  - Doe, John")
+      expect(output).to include("TI  - The Great Emu War")
+      expect(output).to include("PY  - 2023")
+      expect(output).to include("SN  - 9780245839459")
+      expect(output).to include("ER  -")
+    end
 
-  it 'formats a book reference with a date in RIS format' do
-    data = [{
-      type: 'book',
-      author: [{ family: 'Lipson', given: 'Charles' }],
-      date: '15/5/2011',
-      title: 'Cite Right: A Quick Guide to Citation Styles',
-      publisher: 'University of Chicago Press',
-      ISBN: '9780226484648',
-      edition: '1',
-    }]
+    it 'formats a book reference with a date in RIS format' do
+      data = [{
+        type: 'book',
+        author: [{ family: 'Lipson', given: 'Charles' }],
+        date: '15/5/2011',
+        title: 'Cite Right: A Quick Guide to Citation Styles',
+        publisher: 'University of Chicago Press',
+        ISBN: '9780226484648',
+        edition: '1',
+      }]
 
-    output = format_ris(data)
-    expect(output).to include("PY  - 15/5/2011")
-  end
+      output = format_ris(data)
+      expect(output).to include("PY  - 15/5/2011")
+    end
 
-  it 'formats a journal article reference with a date in RIS format' do
-    data = [{
-      type: 'article',
-      author: [{ family: 'Keller', given: 'Maria Eugenia' }],
-      date: '15-05-2011',
-      title: 'Experts perspectives on shared responsibility for speed management: A thematic analysis informed by systems thinking',
-      containertitle: 'Accident Analysis & Prevention',
-      ISSN: '0001-4575',
-      volume: '211',
-    }]
-  
-    output = format_ris(data)
-    expect(output).to include("PY  - 15-05-2011")
+    it 'formats a journal article reference with a date in RIS format' do
+      data = [{
+        type: 'article',
+        author: [{ family: 'Keller', given: 'Maria Eugenia' }],
+        date: '15-05-2011',
+        title: 'Experts perspectives on shared responsibility for speed management: A thematic analysis informed by systems thinking',
+        containertitle: 'Accident Analysis & Prevention',
+        ISSN: '0001-4575',
+        volume: '211',
+      }]
+    
+      output = format_ris(data)
+      expect(output).to include("PY  - 15-05-2011")
 
+    end
+
+    let(:refs) {[
+      'Derrida, J. (c.1967). L’écriture et la différence (1 éd.). Paris: Éditions du Seuil.',
+      'Perec, Georges. A Void. London: The Harvill Press, 02/08/1995. p.108.',
+    ]}
+
+    it 'Parse correctly formats a date in RIS format' do
+      output = ap.parse(refs, format: 'ris', date_format: 'citeproc')
+
+      expect(output).to include("PY  - 02/08/1995")
+
+    end
   end
 end

--- a/spec/anystyle/format/ris_spec.rb
+++ b/spec/anystyle/format/ris_spec.rb
@@ -45,7 +45,7 @@ module AnyStyle
       }]
 
       output = format_ris(data)
-      expect(output).to include("PY  - 15/5/2011")
+      expect(output).to include("DA  - 2011/5/15/")
     end
 
     it 'formats a journal article reference with a date in RIS format' do
@@ -60,7 +60,7 @@ module AnyStyle
       }]
     
       output = format_ris(data)
-      expect(output).to include("PY  - 15-05-2011")
+      expect(output).to include("DA  - 2011/5/15/")
 
     end
 
@@ -72,8 +72,8 @@ module AnyStyle
     it 'Parse correctly formats a date in RIS format' do
       output = ap.parse(refs, format: 'ris', date_format: 'citeproc')
 
-      expect(output).to include("PY  - 02/08/1995")
-
+      expect(output).to include("PY  - 1967///")
+      expect(output).to include("DA  - 1995/8/2/")
     end
   end
 end

--- a/spec/anystyle/format/ris_spec.rb
+++ b/spec/anystyle/format/ris_spec.rb
@@ -30,4 +30,35 @@ describe AnyStyle::Format::RIS do
     expect(output).to include("SN  - 9780245839459")
     expect(output).to include("ER  -")
   end
+
+  it 'formats a book reference with a date in RIS format' do
+    data = [{
+      type: 'book',
+      author: [{ family: 'Lipson', given: 'Charles' }],
+      date: '15/5/2011',
+      title: 'Cite Right: A Quick Guide to Citation Styles',
+      publisher: 'University of Chicago Press',
+      ISBN: '9780226484648',
+      edition: '1',
+    }]
+
+    output = format_ris(data)
+    expect(output).to include("PY  - 15/5/2011")
+  end
+
+  it 'formats a journal article reference with a date in RIS format' do
+    data = [{
+      type: 'article',
+      author: [{ family: 'Keller', given: 'Maria Eugenia' }],
+      date: '15-05-2011',
+      title: 'Experts perspectives on shared responsibility for speed management: A thematic analysis informed by systems thinking',
+      containertitle: 'Accident Analysis & Prevention',
+      ISSN: '0001-4575',
+      volume: '211',
+    }]
+  
+    output = format_ris(data)
+    expect(output).to include("PY  - 15-05-2011")
+
+  end
 end

--- a/spec/anystyle/format/ris_spec.rb
+++ b/spec/anystyle/format/ris_spec.rb
@@ -67,6 +67,10 @@ module AnyStyle
     let(:refs) {[
       'Derrida, J. (c.1967). L’écriture et la différence (1 éd.). Paris: Éditions du Seuil.',
       'Perec, Georges. A Void. London: The Harvill Press, 02/08/1995. p.108.',
+      'Michael, Corvid. The sink hole. Australia: Wiley, 2023-06-05. p.400.',
+      # Citation dates with extra info
+      'Derrida, J. (Spring 2020). L’écriture et la différence (1 éd.). Paris: Éditions du Seuil.',
+      'Perec, Georges. A Void. London: The Harvill Press, 01/03/1993 13:10:40. p.108.',
     ]}
 
     it 'Parse correctly formats a date in RIS format' do
@@ -74,6 +78,16 @@ module AnyStyle
 
       expect(output).to include("PY  - 1967///")
       expect(output).to include("DA  - 1995/8/2/")
+      expect(output).to include("DA  - 2023/6/5/")
     end
+
+    it 'Parse correctly formats a date with extra info in RIS format' do
+      output = ap.parse(refs, format: 'ris', date_format: 'citeproc')
+
+      expect(output).to include("DA  - 2020///Spring")
+      expect(output).to include("DA  - 1993/3/1/13:10:40")
+    end
+
+
   end
 end

--- a/spec/anystyle/format/ris_spec.rb
+++ b/spec/anystyle/format/ris_spec.rb
@@ -12,8 +12,8 @@ describe AnyStyle::Format::RIS do
   it 'formats a book reference in RIS format' do
     data = [{
       type: 'book',
-      author: [{ family: 'Lingard', given: 'Zac' }],
-      issued: '2023',
+      author: [{ family: 'Doe', given: 'John' }],
+      date: '2023',
       title: 'The Great Emu War',
       publisher: 'Wiley',
       ISBN: '9780245839459',
@@ -24,8 +24,10 @@ describe AnyStyle::Format::RIS do
 
     output = format_ris(data)
     expect(output).to include("TY  - BOOK")
-    expect(output).to include("AU  - Lingard, Zac")
+    expect(output).to include("AU  - Doe, John")
     expect(output).to include("TI  - The Great Emu War")
+    expect(output).to include("PY  - 2023")
+    expect(output).to include("SN  - 9780245839459")
     expect(output).to include("ER  -")
   end
 end

--- a/spec/anystyle/format/ris_spec.rb
+++ b/spec/anystyle/format/ris_spec.rb
@@ -45,7 +45,7 @@ module AnyStyle
       }]
 
       output = format_ris(data)
-      expect(output).to include("DA  - 2011/5/15/")
+      expect(output).to include("PY  - 2011///")
     end
 
     it 'formats a journal article reference with a date in RIS format' do
@@ -60,7 +60,7 @@ module AnyStyle
       }]
     
       output = format_ris(data)
-      expect(output).to include("DA  - 2011/5/15/")
+      expect(output).to include("PY  - 2011///")
 
     end
 
@@ -68,26 +68,15 @@ module AnyStyle
       'Derrida, J. (c.1967). L’écriture et la différence (1 éd.). Paris: Éditions du Seuil.',
       'Perec, Georges. A Void. London: The Harvill Press, 02/08/1995. p.108.',
       'Michael, Corvid. The sink hole. Australia: Wiley, 2023-06-05. p.400.',
-      # Citation dates with extra info
-      'Derrida, J. (Spring 2020). L’écriture et la différence (1 éd.). Paris: Éditions du Seuil.',
-      'Perec, Georges. A Void. London: The Harvill Press, 01/03/1993 13:10:40. p.108.',
-    ]}
+    ]} 
 
     it 'Parse correctly formats a date in RIS format' do
       output = ap.parse(refs, format: 'ris', date_format: 'citeproc')
 
       expect(output).to include("PY  - 1967///")
-      expect(output).to include("DA  - 1995/8/2/")
-      expect(output).to include("DA  - 2023/6/5/")
+      expect(output).to include("PY  - 1995///")
+      expect(output).to include("PY  - 2023///")
     end
-
-    it 'Parse correctly formats a date with extra info in RIS format' do
-      output = ap.parse(refs, format: 'ris', date_format: 'citeproc')
-
-      expect(output).to include("DA  - 2020///Spring")
-      expect(output).to include("DA  - 1993/3/1/13:10:40")
-    end
-
 
   end
 end


### PR DESCRIPTION
Adds support for dates when working with RIS.  This is based on [Writing RIS datasets](https://refdb.sourceforge.net/manual-0.9.6/sect1-ris-format.html) guide specifically PY and Y2 and imports supported by both [EndNote](https://endnote.com/) and [Zotero](https://www.zotero.org/).